### PR TITLE
close IB near market close

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -320,7 +320,7 @@ IbAutoClosedown=yes
 # use the following:
 # #ClosedownAt=\u661F\u671F\u516D 12:00
 
-ClosedownAt=3:00
+ClosedownAt=21:30
 
 
 


### PR DESCRIPTION
GCP instances keep time with UTC so 21:30 converts to either 5:30PM EDT or 4:30PM EDT. Previous 3:00 shutdown translated to managing IB servers at 11PM.